### PR TITLE
feat: add language selector when creating a bin

### DIFF
--- a/bin/bin.py
+++ b/bin/bin.py
@@ -10,9 +10,11 @@ languages_exts = {
     'js': 'javascript',
     'md': 'markdown',
     'cs': 'csharp',
-    'sh': 'kotlin',
+    'sh': 'bash',
+    'kt': 'kotlin',
     'h': 'objectivec',
-    'hpp': 'cpp',
+    'cpp': 'cpp',
+    'c': 'c',
     'rb': 'ruby',
     'rs': 'rust',
     'ts': 'typescript',
@@ -37,9 +39,10 @@ def index():
 @bottle.route(path='/new', method='POST')
 def post_new_snippet():
     code = bottle.request.forms.get('code')
+    ext = bottle.request.forms.get('lang')
     snippet = pronounceable_passwd(17)
     snippets[snippet] = code
-    return bottle.redirect(f'/{snippet}')
+    return bottle.redirect(f'/{snippet}.{ext}')
 
 
 @bottle.route(path='/<id>', method='GET')

--- a/bin/public/styles/style.css
+++ b/bin/public/styles/style.css
@@ -7,7 +7,7 @@ body {
     background-color: #1e282d;
     color: #a9a5a5;
 
-    font-family: Consolas;
+    font-family: Consolas, sans-serif;
 
     display: flex;
     padding: 2em 0.5em;
@@ -39,7 +39,7 @@ body {
     width: 100%;
     height: 100%;
 
-    font-family: Consolas;
+    font-family: Consolas, sans-serif;
     color: #a9a5a5;
 }
 
@@ -70,5 +70,5 @@ pre {
 pre code {
     background: transparent !important;
     padding: 0 !important;
-    font-family: Consolas;
+    font-family: Consolas, sans-serif;
 }

--- a/bin/views/index.html
+++ b/bin/views/index.html
@@ -2,6 +2,24 @@
 
     <form action="/new" method="POST" class="post-snippet">
         <textarea spellcheck="false" placeholder="Entrer votre code." name="code" autofocus></textarea>
+        <select name="lang">
+            <option value="txt">Plain text</option>
+            <option value="py">Python</option>
+            <option value="js">JavaScript</option>
+            <option value="md">Markdown</option>
+            <option value="cs">C#</option>
+            <option value="sh">Bash</option>
+            <option value="kt">Kotlin</option>
+            <option value="h">Objective C</option>
+            <option value="cpp">C++</option>
+            <option value="c">C</option>
+            <option value="rb">Ruby</option>
+            <option value="rs">Rust</option>
+            <option value="ts">TypeScript</option>
+            <option value="yml">Yaml</option>
+            <option value="html">HTML</option>
+            <option value="css">CSS</option>
+        </select>
         <button type="submit" aria-label="Publier le bin">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
               <path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z" />


### PR DESCRIPTION
Adding a language selector while creating a snippet. No CSS has been
applied on it, as I do not know this language.

Also, this commit adds and fixes some of the languages written in
bin/bin.py.