### PR TITLE
fix: sans-serif to monospace

### DIFF
--- a/bin/public/styles/style.css
+++ b/bin/public/styles/style.css
@@ -7,7 +7,7 @@ body {
     background-color: #1e282d;
     color: #a9a5a5;
 
-    font-family: Consolas, sans-serif;
+    font-family: Consolas, monospace;
 
     display: flex;
     padding: 2em 0.5em;
@@ -39,7 +39,7 @@ body {
     width: 100%;
     height: 100%;
 
-    font-family: Consolas, sans-serif;
+    font-family: Consolas, monospace;
     color: #a9a5a5;
 }
 
@@ -70,5 +70,5 @@ pre {
 pre code {
     background: transparent !important;
     padding: 0 !important;
-    font-family: Consolas, sans-serif;
+    font-family: Consolas, monospace;
 }


### PR DESCRIPTION
As rtd-bin expects code, a monospace font is prefered to a sans-serif
font.